### PR TITLE
fix(shell): bottom mat. raycast returning invalid hit position;

### DIFF
--- a/funcs/shell/main.lua
+++ b/funcs/shell/main.lua
@@ -329,7 +329,7 @@ local function tick_active(self, delta)
         end
 
         -- QueryRaycast in the opposite direction to check if bottom material is impenetrable. Fixes fringe QueryRejectShape edge case.
-        hit, hit_distance, normal, shape_initial = QueryRaycast(position_new, VecNormalize(VecSub(self.position, position_new)), VecLength(VecSub(self.position, position_new), shell_radius))
+        hit, hit_distance, normal, shape_initial = QueryRaycast(position_new, VecNormalize(VecSub(self.position, position_new)), VecLength(VecSub(self.position, position_new), 0))
         position_initial_hit = VecAdd(position_new, VecScale(VecNormalize(VecSub(self.position, position_new)), hit_distance))
 
         if not hit then return false end


### PR DESCRIPTION
Query raycast with radius returned origin of sphere instead of raycast and shape intersection. The resulting hit position was often in mid-air leading to a null ('') material on sample.